### PR TITLE
Add gz-jetty-launch alias packages

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -70,3 +70,19 @@ Description: Gazebo Launch Library - Development files
  interface to run and manager application and plugins.
  .
  Package contains the Gazebo launch development files and cli client
+
+Package: gz-jetty-launch
+Depends: libgz-launch9-dev (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.
+
+Package: gz-jetty-launch-cli
+Depends: gz-launch9-cli (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.


### PR DESCRIPTION
Add gz-jetty-launch* packages that depend on the
corresponding libgz-launch9* packages.

Part of https://github.com/gazebo-tooling/release-tools/issues/1326.